### PR TITLE
Docs: add system description

### DIFF
--- a/fast-mpsc-queue.asd
+++ b/fast-mpsc-queue.asd
@@ -4,6 +4,8 @@
 (defsystem fast-mpsc-queue
   :license "MIT"
   :homepage "https://github.com/kchanqvq/fast-mpsc-queue"
+  :description "Multi-Producer Single-Consumer queue implementation."
+  :long-description "This is a Multi-Producer Single-Consumer queue implementation specific to SBCL x86-64. It implements the beautiful algorithm found at \"Non-intrusive MPSC node-based queue\", and is intended for developing high-performance Actor systems."
   :depends-on (:metabang-bind)
   :serial t
   :components ((:file "package")


### PR DESCRIPTION
Also add long-description.

Fixes the error http://report.quicklisp.org/2024-07-23/failure-report/fast-mpsc-queue.html during build of the quicklisp dist. See quicklisp/quicklisp-projects#2409